### PR TITLE
fix: format nanos correctly if nanos is 0

### DIFF
--- a/projects/pino-logging-gcp-config/src/pino_gcp_config.spec.ts
+++ b/projects/pino-logging-gcp-config/src/pino_gcp_config.spec.ts
@@ -151,5 +151,14 @@ describe('Pino config', () => {
         ',"timestamp":{"seconds":1713024754,"nanos":123000000}'
       );
     });
+
+    it('adds a timestamp as seconds:nanos JSON fragment when nanos is 0', () => {
+      jasmine.clock().mockDate(new Date('2024-04-13T16:12:34.000Z'));
+      const timestampGenerator = config.timestamp as () => string;
+
+      expect(timestampGenerator()).toEqual(
+        ',"timestamp":{"seconds":1713024754,"nanos":0}'
+      );
+    });
   });
 });

--- a/projects/pino-logging-gcp-config/src/pino_gcp_config.ts
+++ b/projects/pino-logging-gcp-config/src/pino_gcp_config.ts
@@ -177,7 +177,11 @@ class GcpLoggingPino {
     // eg for a Date.now()=1713024754120
     // (seconds-secondsRounded)*1000 => 119.99988555908203
     const millis = Math.round((seconds - secondsRounded) * 1000);
-    return `,"timestamp":{"seconds":${secondsRounded},"nanos":${millis}000000}`;
+    if (millis !== 0) {
+      return `,"timestamp":{"seconds":${secondsRounded},"nanos":${millis}000000}`;
+    } else {
+      return `,"timestamp":{"seconds":${secondsRounded},"nanos":0}`;
+    }
   }
 
   /**


### PR DESCRIPTION
`@opentelemetry/instrumentation-pino` will fail to parse the formatted json string, if nanos is `0` because `000000` can not be parsed as number by `JSON.parse`. The instrumentation fails with the following error:
```@opentelemetry/instrumentation-pino could not send pino log line```

This PR adds a test and fixes that issue.