### PR TITLE
fix: wrong `logging.googleapis.com/trace` format

### DIFF
--- a/projects/pino-logging-gcp-config/src/pino_gcp_config.ts
+++ b/projects/pino-logging-gcp-config/src/pino_gcp_config.ts
@@ -76,8 +76,17 @@ export interface GCPLoggingPinoOptions {
   serviceContext?: ServiceContext;
 
   /**
+   * Optional Google Cloud project ID to be used for composing the
+   * 'logging.googleapis.com/trace' field.
+   *
+   * If not specified, the project ID will be auto-detected from the
+   * environment.
+   */
+  traceGoogleCloudProjectId?: string;
+
+  /**
    * Optional GoogleAuth - used to override defaults when detecting
-   * ServiceContext from the environment.
+   * ServiceContext and project ID from the environment.
    */
   auth?: gax.GoogleAuth;
 }
@@ -88,8 +97,37 @@ export interface GCPLoggingPinoOptions {
  */
 class GcpLoggingPino {
   serviceContext: ServiceContext | null = null;
+  traceGoogleCloudProjectId: string | null = null;
 
   constructor(options?: GCPLoggingPinoOptions) {
+    this.initializeOptionsAsync(options).then(
+      () => {
+        this.outputDiagnosticEntry();
+      },
+      () => {
+        // Ignore any errors raised by resolveOptions.
+        // Errors can occur if not running in a GCP environment.
+      }
+    );
+  }
+
+  /**
+ * Resolves and initializes the configuration options for the logger.
+ *
+ * This function sets up the `serviceContext` and `traceGoogleCloudProjectId` 
+ * properties for the logger. It uses the provided options or attempts to 
+ * auto-detect values from the environment if they are not specified.
+ *
+ * @param options Configuration options for GCP logging.
+ * 
+ * @throws {Error} If `serviceContext.service` is provided but is not a valid 
+ * string or is empty.
+ */
+  async initializeOptionsAsync(options?: GCPLoggingPinoOptions) {
+    // Initializing a Cloud Logger for if we need to retrieve the
+    // ServiceContext and project ID automatically from the environment.
+    const cloudLog = new Logging({auth: options?.auth});
+
     if (options?.serviceContext) {
       if (
         typeof options.serviceContext?.service !== 'string' ||
@@ -98,27 +136,18 @@ class GcpLoggingPino {
         throw new Error('options.serviceContext.service must be specified.');
       }
       this.serviceContext = {...options.serviceContext};
-      this.outputDiagnosticEntry();
     } else {
-      // Use the Cloud Logging libraries to retrieve the ServiceContext
-      // automatically from the environment.
-      //
-      // This requires initialising a Cloud Logger, then using
-      // detectServiceContext to asynchronously return the ServiceContext
-      const cloudLog = new Logging({auth: options?.auth}).logSync(
-        NODEJS_GCP_PINO_LIBRARY_NAME
-      );
+      // Using detectServiceContext to asynchronously return the ServiceContext
+      const serviceContext = await detectServiceContext(cloudLog.auth);
+      this.serviceContext = serviceContext;
+    }
 
-      detectServiceContext(cloudLog.logging.auth).then(
-        serviceContext => {
-          this.serviceContext = serviceContext;
-          this.outputDiagnosticEntry();
-        },
-        () => {
-          // Ignore any errors raised by detectServiceContext.
-          // Errors can occur if not running in a GCP environment.
-        }
-      );
+    if (options?.traceGoogleCloudProjectId) {
+      this.traceGoogleCloudProjectId = options.traceGoogleCloudProjectId;
+    } else {
+      // Using the GoogleAuth to get the projectId from the environment.
+      const projectId = await cloudLog.auth.getProjectId();
+      this.traceGoogleCloudProjectId = projectId;
     }
   }
 
@@ -217,7 +246,9 @@ class GcpLoggingPino {
     // @see https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
     // @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#trace-context-fields
     if ((entry.trace_id as string | undefined)?.length) {
-      entry['logging.googleapis.com/trace'] = entry.trace_id;
+      entry['logging.googleapis.com/trace'] = this.traceGoogleCloudProjectId
+        ? `projects/${this.traceGoogleCloudProjectId}/traces/${entry.trace_id}`
+        : entry.trace_id;
       delete entry.trace_id;
     }
     if ((entry.span_id as string | undefined)?.length) {


### PR DESCRIPTION
## Scope

`pino-logging-gcp-config`

## Summary

Based on the [structured logging documentation](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields), `logging.googleapis.com/trace` field needs to be in the `projects/[PROJECT-ID]/traces/[TRACE-ID]` format unless a special flag is set in the log injector.

Since we do not have control over the log injector in some Google Cloud services (e.g., Cloud Run), we should format the trace ID correctly whenever possible.

If the trace field does not follow the required format, Cloud Trace Explorer can NOT associate logs with their corresponding traces and spans.

## What's changed

* Add a new traceGoogleCloudProjectId option to specify the project ID used when composing the trace field. If not specific it'll try to detect the project ID using `GoogleAuth<>.getProjectId` function from the google-auth-library
* Move asynchronous environment detection operations into a new `initializeOptionsAsync` function
* Corrected a test case description to reflect its behavior
* Added a new test to verify the correct formatting of trace fields when a project ID is provided

## Notes on implementation and compatibility

* LogSync initialization has been removed since `detectServiceContext` does not need `LogSync` to be initialized, it only relies on the `GoogleAuth`.
* This library is already using the Cloud Logger library to detect the `ServiceContext`, we can leverage its dependency `google-auth-library` to automatically retrieve the project ID from the environment. This eliminates the need to make the `traceGoogleCloudProjectId` option mandatory like the Google Cloud .NET SDK, ensuring backward compatibility and preventing code breakage during upgrades.
* If the project ID cannot be detected from the environment, the behavior will remain unchanged, and the trace ID will be output without formatting.

This change is compatible with the existing version.

| `traceGoogleCloudProjectId` is set | Project ID can be detected | Scenario            | Behavior                                                                      |
| ---------------------------------- | -------------------------- | ------------------- | ----------------------------------------------------------------------------- |
| No                                 | Yes                        | On the Google Cloud | Formats the trace ID using the project ID from the environment or metadata server |
| No                                 | No                         | Local development   | Output trace ID as it is                                                      |
| Yes                                | N/A                        | Testing             | Formats the trace ID using the provided project ID                            |

## Reference
* Similar behavior in the existing Google Cloud .NET SDK
https://github.com/googleapis/google-cloud-dotnet/blob/ddb48fb6e336497d9ba0b7b8dd90f2d916320363/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/GoogleCloudConsoleFormatter.cs#L257
* How `GoogleAuth<>.getProjectId` detects the project ID from the environment variable and metadata server
https://github.com/googleapis/google-auth-library-nodejs/blob/813a63aadfbeb1d136b345b927431c1473bb3fe6/src/auth/googleauth.ts#L256