### PR TITLE
fix(pino-logging-gcp-config): log mutates input

### DIFF
--- a/projects/pino-logging-gcp-config/src/pino_gcp_config.spec.ts
+++ b/projects/pino-logging-gcp-config/src/pino_gcp_config.spec.ts
@@ -144,6 +144,13 @@ describe('Pino config', () => {
       expect(formattedLog.trace_flags).toBeUndefined();
     });
 
+    it('should not mutate input', () => {
+      const input = {}
+      formatLogObject(input);
+
+      expect(input).toEqual({});
+    });
+
     it('adds a timestamp as seconds:nanos JSON fragment', () => {
       const timestampGenerator = config.timestamp as () => string;
 

--- a/projects/pino-logging-gcp-config/src/pino_gcp_config.ts
+++ b/projects/pino-logging-gcp-config/src/pino_gcp_config.ts
@@ -255,13 +255,14 @@ class GcpLoggingPino {
    * * Adds serviceContext
    * * Adds sequential insertId to preserve logging order.
    */
-  formatLogObject(entry: Record<string, unknown>): Record<string, unknown> {
+  formatLogObject(input: Record<string, unknown>): Record<string, unknown> {
     // OpenTelemetry adds properties trace_id, span_id, trace_flags. If these
     // are present, not null and not blank, convert them to the property keys
     // specified by GCP logging.
     //
     // @see https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
     // @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#trace-context-fields
+    const entry = {...input}
     if ((entry.trace_id as string | undefined)?.length) {
       entry['logging.googleapis.com/trace'] = this.traceGoogleCloudProjectId
         ? `projects/${this.traceGoogleCloudProjectId}/traces/${entry.trace_id}`


### PR DESCRIPTION
# `formatLogObject` mutates input

Pino supports passing [mergingObject](https://github.com/pinojs/pino/blob/main/docs/api.md#logging-method-parameters) as the first parameter for logging. Current implementation mutates the passed object instead of its copy (e.g. https://github.com/pinojs/pino/blob/116b1b17935630b97222fbfd1c053d199d18ca4b/test/formatters.test.js#L85).

We noticed the issue as we had request body passed as the first argument to pino logging.

## Expected behaviour

```js
const obj = {foo: "bar"}
pino(createGcpLoggingPinoConfig(
  { serviceContext: { service: "..." } },
  {},
)).info(obj)
// obj is still {foo: 'bar'}
```

## Current behaviour

```js
const obj = {foo: "bar"}
pino(createGcpLoggingPinoConfig(
  { serviceContext: { service: "..." } },
  {},
)).info(obj)
// obj is now {
//   foo: 'bar',
//   serviceContext: { service: '...' },
//   'logging.googleapis.com/insertId': '...'
// }
```