### PR TITLE
feat(pino-logging-gcp-config): support pino v10

### DIFF
--- a/projects/pino-logging-gcp-config/package-lock.json
+++ b/projects/pino-logging-gcp-config/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/logging": "^11.2.1",
         "eventid": "^2.0.1",
-        "pino": "^9.9.5"
+        "pino": "^9.9.5 || ^10.0.0"
       },
       "devDependencies": {
         "@types/jasmine": "^5.1.9",

--- a/projects/pino-logging-gcp-config/package.json
+++ b/projects/pino-logging-gcp-config/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@google-cloud/logging": "^11.2.1",
     "eventid": "^2.0.1",
-    "pino": "^9.9.5"
+    "pino": "^9.9.5 || ^10.0.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
This pull request adds support for pino v10 in the pino-logging-gcp-config project. pino v10 introduced no breaking changes except dropping support for Node.js v18 [^1].

[^1]: https://github.com/pinojs/pino/releases/tag/v10.0.0